### PR TITLE
Do not follow cursors from system headers

### DIFF
--- a/src/source/translation_unit/mod.rs
+++ b/src/source/translation_unit/mod.rs
@@ -79,9 +79,13 @@ extern "C" fn traverse_cursor(
     client_data: *mut core::ffi::c_void,
 ) -> CXChildVisitResult {
     unsafe {
-        let translation_unit = &mut *(client_data as *mut TU);
-        translation_unit.cursors.push(current.into());
-        clang_visitChildren(current, traverse_cursor, client_data);
+        if clang_Location_isInSystemHeader(clang_getCursorLocation(current)) == 0 {
+            let translation_unit = &mut *(client_data as *mut TU);
+            translation_unit.cursors.push(current.into());
+            clang_visitChildren(current, traverse_cursor, client_data);
+        } else {
+            ()
+        }
     }
     CXChildVisit_Continue
 }

--- a/tests/class.h
+++ b/tests/class.h
@@ -1,6 +1,6 @@
 #ifndef CLASS_H
 #define CLASS_H
-
+#include <iostream>
 namespace my_namespace {
 class MyTestClass {
   struct PrivateStruct {};


### PR DESCRIPTION
Do not follow cursors from system headers since
I do not want to process them anyway